### PR TITLE
Used Uint8List instead of List<int> for performance improvement.

### DIFF
--- a/lib/bignum.dart
+++ b/lib/bignum.dart
@@ -1,4 +1,5 @@
 library bignum;
 
 import 'dart:math' as Mathx;
+import 'dart:typed_data';
 part 'src/BigInteger_v8/big_integer.dart';

--- a/lib/src/BigInteger_v8/big_integer.dart
+++ b/lib/src/BigInteger_v8/big_integer.dart
@@ -366,7 +366,7 @@ class BigInteger {
     // Add a leading 0 if most significant bit set (otherwise, the magnitude
     // is interpreted as negative and this constructor fails)
     if( (magnitude[0] & 0x80) != 0 ) {
-      magnitude = new List<int>(1+magnitude.length)
+      magnitude = new Uint8List(1+magnitude.length)
           ..[0] = 0
           ..setRange(1, 1+magnitude.length, magnitude);
     }


### PR DESCRIPTION
Used Uint8List instead of List<int> for performance improvement.

The method is called `fromBytes` so it's likely that the parameter passed will be of type `Uint8List`. Now the `List.setRange()` implementation will copy the list element-wise, while `Uint8List.setRange()`, when passed another `Uint8List`, will use native code optimized to copy arbitrarily sized chunks of bytes.
