### PR TITLE
Upgraded fixnum dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.7
 homepage: https://github.com/Dartist/dart-bignum
 description: Big Number library for Dart
 dependencies:
-  fixnum: '>=0.9.0 <0.10.0'
+  fixnum: '>=0.10.2 <0.11.0'
 dev_dependencies:
   unittest: '>=0.9.0 <0.10.0'
 environment:


### PR DESCRIPTION
The fixnum library has been on v0.10.2 for some time. Even though there is little transparency about what happened since v0.9.x (they don't have a repo or anything), I suspect mostly performance improvements.

I ran all tests with the new version and they all worked fine, so I think this can only be for the better.