### PR TITLE
Add type annotations to fix strong-mode errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 packages
+.packages
 .project
 .children
 pubspec.lock

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+analyzer:
+ strong-mode: true

--- a/lib/bignum.dart
+++ b/lib/bignum.dart
@@ -59,45 +59,45 @@ abstract class BigInteger {
       return new BigIntegerDartvm.fromBytes(signum, magnitude);
     }
   }
-   BigInteger operator %( other);
+   BigInteger operator %(covariant BigInteger other);
 
-   BigInteger operator &( other);
+   BigInteger operator &(covariant BigInteger other);
 
-   BigInteger operator *( other);
+   BigInteger operator *(covariant BigInteger other);
 
-   BigInteger operator +( other);
+   BigInteger operator +(covariant BigInteger other);
 
    BigInteger operator -();
 
-   BigInteger operator -( other);
+   BigInteger operator -(covariant BigInteger other);
 
-   BigInteger operator /( other);
+   BigInteger operator /(covariant BigInteger other);
 
-   bool operator <( other);
+   bool operator <(covariant BigInteger other);
 
    BigInteger operator <<(int shiftAmount);
 
-   bool operator <=( other);
+   bool operator <=(covariant BigInteger other);
 
-   bool operator >( other);
+   bool operator >(covariant BigInteger other);
 
-   bool operator >=( other);
+   bool operator >=(covariant BigInteger other);
 
    BigInteger operator >>(int shiftAmount);
 
-   BigInteger operator ^( other);
+   BigInteger operator ^(covariant BigInteger other);
 
    BigInteger abs();
 
-   BigInteger add(a);
+   BigInteger add(covariant BigInteger a);
 
-   void bitwiseTo(a, Function op, r);
-   
-   addTo(a, r);
+   void bitwiseTo(covariant BigInteger a, Function op, covariant BigInteger r);
 
-   and(a);
+   addTo(covariant BigInteger a, covariant BigInteger r);
 
-   andNot(a);
+   and(covariant BigInteger a);
+
+   andNot(covariant BigInteger a);
 
    bitCount();
 
@@ -105,7 +105,7 @@ abstract class BigInteger {
 
    byteValue();
 
-   cbit(x);
+   int cbit(int x);
 
    clearBit(n);
 
@@ -113,18 +113,18 @@ abstract class BigInteger {
 
    int compareTo(a);
 
-   void copyTo( r);
+   void copyTo(covariant BigInteger r);
 
    dMultiply(n);
    dAddOffset(n,w);
-   
-   divRemTo( m, q,  r);
 
-   BigInteger divide(a);
+   divRemTo(covariant BigInteger m, covariant BigInteger q, covariant BigInteger r);
 
-   Map<int, BigInteger> divideAndRemainder(a);
+   BigInteger divide(covariant BigInteger a);
 
-   bool equals( a);
+   Map<int, BigInteger> divideAndRemainder(covariant BigInteger a);
+
+   bool equals(covariant BigInteger a);
 
    BigInteger exp(int e, z);
 
@@ -134,9 +134,9 @@ abstract class BigInteger {
 
    void fromRadix(s, b);
 
-   void fromString(s, int b);
+   void fromString(String s, int b);
 
-   gcd(a);
+   gcd(covariant BigInteger a);
 
    getLowestSetBit();
 
@@ -148,32 +148,32 @@ abstract class BigInteger {
 
    bool isProbablePrime(int t);
 
-   void lShiftTo(n, r);
+   void lShiftTo(int n, covariant BigInteger r);
 
-   lbit(x);
+   int lbit(int x);
 
    // TODO: implement lowestSetBit
    int get lowestSetBit;
 
-   BigInteger max( a);
+   BigInteger max(covariant BigInteger a);
 
    bool millerRabin(t);
 
-   BigInteger min( a);
+   BigInteger min(covariant BigInteger a);
 
-   mod(a);
+   mod(covariant BigInteger a);
 
    int modInt(int n);
 
-   BigInteger modInverse( m);
+   BigInteger modInverse(covariant BigInteger m);
 
-   modPow( e,  m);
+   modPow(covariant BigInteger e, covariant BigInteger m);
 
-   BigInteger modPowInt(int e,  m);
+   BigInteger modPowInt(int e, covariant BigInteger m);
 
-   BigInteger multiply(a);
+   BigInteger multiply(covariant BigInteger a);
 
-   void multiplyTo(a, r);
+   void multiplyTo(covariant BigInteger a, covariant BigInteger r);
 
    int nbits(x);
 
@@ -189,13 +189,13 @@ abstract class BigInteger {
 
    op_xor(x, y);
 
-   or(a);
+   or(covariant BigInteger a);
 
    BigInteger pow(int e);
 
    void rShiftTo(int n, r);
 
-   BigInteger remainder( a);
+   BigInteger remainder(covariant BigInteger a);
 
    setBit(n);
 
@@ -209,10 +209,9 @@ abstract class BigInteger {
 
    void squareTo(r);
 
-   void subTo(a, r);
+   void subTo(covariant BigInteger a, covariant BigInteger r);
 
-   BigInteger subtract(a);
-
+   BigInteger subtract(covariant BigInteger a);
 
    testBit(n);
 
@@ -222,11 +221,11 @@ abstract class BigInteger {
 
    String toString([int b]);
 
-   xor(a);
+   xor(covariant BigInteger a);
 
-   BigInteger operator |( other);
+   BigInteger operator |(covariant BigInteger other);
 
    BigInteger operator ~();
 
-   BigInteger operator ~/( other);
+   BigInteger operator ~/(covariant BigInteger other);
 }

--- a/lib/src/big_integer_dartvm.dart
+++ b/lib/src/big_integer_dartvm.dart
@@ -347,7 +347,7 @@ class BigIntegerDartvm implements BigInteger {
   }
 
   /** r = this << n */
-  void lShiftTo(int n, r) {
+  void lShiftTo(int n, BigIntegerDartvm r) {
     r.data = data << n;
   }
 
@@ -357,7 +357,7 @@ class BigIntegerDartvm implements BigInteger {
   }
 
   /** r = this - a */
-  void subTo(a, r) {
+  void subTo(BigIntegerDartvm a, BigIntegerDartvm r) {
     r.data = data - a.data;
   }
 
@@ -365,7 +365,7 @@ class BigIntegerDartvm implements BigInteger {
    * r = this * a, r != this,a (HAC 14.12)
    * [this] should be the larger one if appropriate.
    */
-  void multiplyTo(a, r) {
+  void multiplyTo(BigIntegerDartvm a, BigIntegerDartvm r) {
     r.data = data * a.data;
   }
 
@@ -384,7 +384,7 @@ class BigIntegerDartvm implements BigInteger {
   }
 
   /** this mod a */
-  mod(a) {
+  mod(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data % a.data);
   }
 
@@ -528,7 +528,7 @@ class BigIntegerDartvm implements BigInteger {
   op_and(x, y) {
     return x & y;
   }
-  and(a) {
+  and(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data & a.data);
   }
 
@@ -537,7 +537,7 @@ class BigIntegerDartvm implements BigInteger {
     return x | y;
   }
 
-  or(a) {
+  or(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data | a.data);
   }
 
@@ -545,7 +545,7 @@ class BigIntegerDartvm implements BigInteger {
   op_xor(x, y) {
     return x ^ y;
   }
-  xor(a) {
+  xor(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data ^ a.data);
   }
 
@@ -553,7 +553,7 @@ class BigIntegerDartvm implements BigInteger {
   op_andnot(x, y) {
     return x & ~y;
   }
-  andNot(a) {
+  andNot(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data & ~a.data);
   }
 
@@ -644,27 +644,27 @@ class BigIntegerDartvm implements BigInteger {
   }
 
   /** r = this + a */
-  addTo(a, r) {
+  addTo(BigIntegerDartvm a, BigIntegerDartvm r) {
     r.data = data + a.data;
   }
 
   /** this + a */
-  BigIntegerDartvm add(a) {
+  BigIntegerDartvm add(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data + a.data);
   }
 
   /** this - a */
-  BigIntegerDartvm subtract(a) {
+  BigIntegerDartvm subtract(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data - a.data);
   }
 
   /** this * a */
-  BigIntegerDartvm multiply(a) {
+  BigIntegerDartvm multiply(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data * a.data);
   }
 
   /** this / a */
-  BigIntegerDartvm divide(a) {
+  BigIntegerDartvm divide(BigIntegerDartvm a) {
     return new BigIntegerDartvm(data ~/ a.data);
   }
 
@@ -707,7 +707,7 @@ class BigIntegerDartvm implements BigInteger {
   }
 
   /** gcd(this,a) (HAC 14.54) */
-  gcd(v) {
+  gcd(BigIntegerDartvm v) {
     return new BigIntegerDartvm(data.gcd(v.data));
   }
 

--- a/lib/src/big_integer_v8.dart
+++ b/lib/src/big_integer_v8.dart
@@ -474,7 +474,7 @@ class BigIntegerV8 implements BigInteger {
   }
 
   /** set from string [s] and radix [b] */
-  void fromString(s, int b) {
+  void fromString(dynamic s, int b) {
     var this_array = this.array;
     var k;
     if(b == 16) { k = 4;
@@ -621,7 +621,7 @@ class BigIntegerV8 implements BigInteger {
   }
 
   /** r = this << n */
-  void lShiftTo(n,r) {
+  void lShiftTo(n,BigIntegerV8 r) {
     var this_array = this.array;
     var r_array = r.array;
     var bs = n%BI_DB;
@@ -678,7 +678,7 @@ class BigIntegerV8 implements BigInteger {
   }
 
   /** r = this - a */
-  void subTo(a,r) {
+  void subTo(BigIntegerV8 a, BigIntegerV8 r) {
     var this_array = this.array;
     var r_array = r.array;
     var a_array = a.array;
@@ -744,7 +744,7 @@ class BigIntegerV8 implements BigInteger {
    * r = this * a, r != this,a (HAC 14.12)
    * [this] should be the larger one if appropriate.
    */
-  void multiplyTo(a,r) {
+  void multiplyTo(BigIntegerV8 a, BigIntegerV8 r) {
     var this_array = this.array;
     var r_array = r.array;
     BigIntegerV8 x = this.abs();
@@ -1266,7 +1266,7 @@ class BigIntegerV8 implements BigInteger {
   flipBit(n) { return this.changeBit(n,op_xor); }
 
   /** r = this + a */
-  addTo(a,r) {
+  addTo(BigIntegerV8 a, BigIntegerV8 r) {
     var this_array = this.array;
     var a_array = a.array;
     var r_array = r.array;
@@ -1380,7 +1380,7 @@ class BigIntegerV8 implements BigInteger {
    * r = lower n words of "this * a", a.t <= n
    * "this" should be the larger one if appropriate.
    */
-  multiplyLowerTo(a,n,r) {
+  multiplyLowerTo(BigIntegerV8 a, int n, BigIntegerV8 r) {
     var r_array = r.array;
     var a_array = a.array;
     var i = Mathx.min(this.t+a.t,n);
@@ -1477,7 +1477,7 @@ class BigIntegerV8 implements BigInteger {
   }
 
   /** gcd(this,a) (HAC 14.54) */
-  gcd(a) {
+  gcd(BigIntegerV8 a) {
     var x = (this.s<0)?this.negate_op():this.clone();
     var y = (a.s<0)?a.negate_op():a.clone();
     if(x.compareTo(y) < 0) { var t = x; x = y; y = t; }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bignum
 author: Adam Singer <financeCoding@gmail.com>
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/Dartist/dart-bignum
 description: Big Number library for Dart
 dependencies:
@@ -8,4 +8,4 @@ dependencies:
 dev_dependencies:
   unittest: '>=0.9.0 <0.10.0'
 environment:
-  sdk: ">=1.11.0"
+  sdk: '>=1.22.1 <2.0.0'


### PR DESCRIPTION
- Add analysis_options so the analyzer runs in strong mode
- Add `covariant BigInteger` to many method arguments to fix errors
  where a function taking a specific type was overriding a method taking
  `dynamic`.
- Add specific type arguments to methods which use fields from the
  implementations that don't exist on `BigInteger`
- Restrict SDK to >1.22 to pick up `covariant` keyword

This is the minimal change to make the package strong mode clean, and
hopefully compatible with DDC.